### PR TITLE
Ensure trimPath{Start,End,Offset} wraparound 1 correctly

### DIFF
--- a/app/components/canvas/canvas.js
+++ b/app/components/canvas/canvas.js
@@ -245,23 +245,22 @@ class CanvasController {
           ctx.miterLimit = layer.miterLimit || 10;
 
           if (layer.trimPathStart !== 0 || layer.trimPathEnd !== 1 || layer.trimPathOffset !== 0) {
-            // Calculate the normalized length of the trimmed path. If trimPathStart
+            // Calculate the visible fraction of the trimmed path. If trimPathStart
             // is greater than trimPathEnd, then the result should be the combined
             // length of the two line segments: [trimPathStart,1] and [0,trimPathEnd].
-            let trimPathLengthNormalized = layer.trimPathEnd - layer.trimPathStart;
+            let shownFraction = layer.trimPathEnd - layer.trimPathStart;
             if (layer.trimPathStart > layer.trimPathEnd) {
-              trimPathLengthNormalized += 1;
+              shownFraction += 1;
             }
-
-            // Calculate the absolute length of the trim path by multiplying the
-            // normalized length with the actual length of the path.
-            let trimPathLength = trimPathLengthNormalized * layer.pathData.length;
-
+            
             // Calculate the dash array. The first array element is the length of
             // the trimmed path and the second element is the gap, which is the
-            // difference in length between the total path length and the trimmed
-            // path length.
-            ctx.setLineDash([trimPathLength, (layer.pathData.length - trimPathLength)]);
+            // difference in length between the total path length and the visible
+            // trimmed path length.
+            ctx.setLineDash([
+              shownFraction * layer.pathData.length, 
+              layer.pathData.length * (1 - shownFraction)
+            ]);
 
             // The amount to offset the path is equal to the trimPathStart plus
             // trimPathOffset. We mod the result because the trimmed path


### PR DESCRIPTION
This adds support for the case where trimPathStart is
greater than trimPathEnd and the case where trimPathOffset
causes the path to wraparound 1. These are the calculations
I used in my blog post on icon animations (which were based
off of some code I copied from Mantis). LMK if the "+ 0.001" is
necessary for some reason... I'm not sure why that was there
in the old code. Also let me know if there are other parts of the
web app need to be updated as well.