### PR TITLE
Fix svg color to android color import

### DIFF
--- a/app/scripts/colorutil.js
+++ b/app/scripts/colorutil.js
@@ -63,13 +63,12 @@ export const ColorUtil = {
     if (color == 'none') {
       return null;
     }
-
-    color = tinycolor(color);
-    if (opacity) {
-      color.setAlpha(opacity);
+    if (!opacity) {
+      opacity = 1;
     }
-
-    return color.toHex8String();
+    let colorHex = tinycolor(color).toHex();
+    let opacityHex = Math.floor(opacity * 255).toString(16);
+    return '#' + opacityHex + colorHex;
   },
 
   androidToCssColor(androidColor, multAlpha) {

--- a/app/scripts/colorutil.js
+++ b/app/scripts/colorutil.js
@@ -59,16 +59,14 @@ export const ColorUtil = {
     return str;
   },
 
-  svgToAndroidColor(color, opacity) {
+  svgToAndroidColor(color) {
     if (color == 'none') {
       return null;
     }
-    if (!opacity) {
-      opacity = 1;
-    }
-    let colorHex = tinycolor(color).toHex();
-    let opacityHex = Math.floor(opacity * 255).toString(16);
-    return '#' + opacityHex + colorHex;
+    color = tinycolor(color);
+    let colorHex = color.toHex();
+    let alphaHex = color.toHex8().substr(6);
+    return '#' + alphaHex + colorHex;
   },
 
   androidToCssColor(androidColor, multAlpha) {

--- a/app/scripts/svgloader.js
+++ b/app/scripts/svgloader.js
@@ -125,9 +125,9 @@ export const SvgLoader = {
         return Object.assign(layerData, {
           id: makeFinalNodeId_('path'),
           pathData: path,
-          fillColor: ColorUtil.svgToAndroidColor(context.fillColor, context.fillOpacity),
+          fillColor: ('fillColor' in context) ? ColorUtil.svgToAndroidColor(context.fillColor) : null,
           fillAlpha: ('fillAlpha' in context) ? context.fillAlpha : 1,
-          strokeColor: ColorUtil.svgToAndroidColor(context.strokeColor, context.strokeOpacity),
+          strokeColor: ('strokeColor' in context) ? ColorUtil.svgToAndroidColor(context.strokeColor) : null,
           strokeAlpha: ('strokeAlpha' in context) ? context.strokeAlpha : 1,
           strokeWidth: context.strokeWidth || 0,
           strokeLinecap: context.strokeLinecap || 'butt',


### PR DESCRIPTION
The previous code wasn't importing translucent SVG colors correctly. First, the `tinycolor2` module seems to create hex colors with the alpha bits at the end of the string (i.e. `#000000ff` instead of `#ff000000` to represent black). Second, the previous code was baking the SVG's fill and stroke opacities directly into the rgba colors. We don't want to do this; we want to let each have their own alpha channels instead.

This fixes #53.