### PR TITLE
Add angular dep to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,5 +15,8 @@
     "angular-material": "~1.1",
     "jquery": "~2.1.4",
     "angular-route": "^1.5.5"
+  },
+  "resolutions": {
+    "angular": "1.6.0"
   }
 }


### PR DESCRIPTION
Every time I do a clean build I have to specify a specific version of angular to use. This was the recommended change to persist the option.