### PR TITLE
use black as the default fill color

### DIFF
--- a/app/scripts/SvgLoader.js
+++ b/app/scripts/SvgLoader.js
@@ -126,7 +126,7 @@ export const SvgLoader = {
         return Object.assign(layerData, {
           id: makeFinalNodeId_('path'),
           pathData: path,
-          fillColor: ('fillColor' in context) ? ColorUtil.svgToAndroidColor(context.fillColor) : null,
+          fillColor: ('fillColor' in context) ? ColorUtil.svgToAndroidColor(context.fillColor) : "#ff000000",
           fillAlpha: ('fillAlpha' in context) ? context.fillAlpha : 1,
           strokeColor: ('strokeColor' in context) ? ColorUtil.svgToAndroidColor(context.strokeColor) : null,
           strokeAlpha: ('strokeAlpha' in context) ? context.strokeAlpha : 1,


### PR DESCRIPTION
According to the SVG spec, the fill color of a path should be black by default: https://www.w3.org/TR/SVG/painting.html

Fixes #111.