### PR TITLE
Correctly import default strokeMiterLimit value

### DIFF
--- a/app/scripts/SvgLoader.js
+++ b/app/scripts/SvgLoader.js
@@ -133,7 +133,7 @@ export const SvgLoader = {
           strokeWidth: context.strokeWidth || 0,
           strokeLinecap: context.strokeLinecap || DefaultValues.LINECAP,
           strokeLinejoin: context.strokeLinejoin || DefaultValues.LINEJOIN,
-          strokeMiterLimit: context.strokeMiterLimit || DefaultValues.MITER_LIMIT,
+          strokeMiterLimit: ('strokeMiterLimit' in context) ? context.strokeMiterLimit : DefaultValues.MITER_LIMIT,
         });
       }
 


### PR DESCRIPTION
If the user specifies '0' as the strokeMiterLimit, then we would want to respect that decision. Currently since 0 is non-truthy, we will replace that explicit decision with the default miter limit of '4'. This change ensures that we only use the default value when no initial value has been specified.