### PR TITLE
Fix possible crash

### DIFF
--- a/app/scripts/model/properties/EnumProperty.js
+++ b/app/scripts/model/properties/EnumProperty.js
@@ -17,7 +17,7 @@
 import {Property} from './Property';
 
 export class EnumProperty extends Property {
-  constructor(name, options = {}, config = {}) {
+  constructor(name, options, config = {}) {
     super(name, config);
     this.optionsByValue_ = {};
     this.options_ = (options || []).map(option => {


### PR DESCRIPTION
I'm pretty sure it doesn't make sense to use a default value here... because calling map on the empty object will cause a crash. In other parts of the project, you pass an array as the second argument, so this seems like it was unintentional.

Discovered as I was trying to rewrite some of your code using TypeScript... :D